### PR TITLE
[ADD] l10n_us_uom_profile: Add default UoMs for USA

### DIFF
--- a/l10n_us_uom_profile/README.rst
+++ b/l10n_us_uom_profile/README.rst
@@ -1,0 +1,57 @@
+.. image:: https://img.shields.io/badge/licence-LGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+   :alt: License: LGPL-3
+
+=========================
+USA - Default UOM Profile
+=========================
+
+This module sets the following UoM defaults for the `en_US` language:
+
+* Hour (Working Time)
+* Pound (Weight)
+* Inch (Length)
+* Oz (Volume)
+* Unit (Unit)
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/203/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/server-tools/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Dave Lasley <dave@laslabs.com>
+
+Do not contact contributors directly about support or help with technical issues.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/l10n_us_uom_profile/__init__.py
+++ b/l10n_us_uom_profile/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).

--- a/l10n_us_uom_profile/__manifest__.py
+++ b/l10n_us_uom_profile/__manifest__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+{
+    'name': 'USA - UoM Profile',
+    'summary': 'This module provides a default UoM profile for USA',
+    'version': '10.0.1.0.0',
+    'category': 'Extra Tools',
+    'website': 'https://laslabs.com/',
+    'author': 'LasLabs, '
+              'Odoo Community Association (OCA)',
+    'license': 'LGPL-3',
+    'application': False,
+    'installable': True,
+    'depends': [
+        'base_locale_uom_default',
+    ],
+    'data': [
+        'data/res_lang_data.xml',
+    ],
+}

--- a/l10n_us_uom_profile/data/res_lang_data.xml
+++ b/l10n_us_uom_profile/data/res_lang_data.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record id="base.lang_en" model="res.lang">
+        <field name="default_uom_ids" eval="[(6, 0, [
+                    ref('product.product_uom_unit'),
+                    ref('product.product_uom_hour'),
+                    ref('product.product_uom_lb'),
+                    ref('product.product_uom_inch'),
+                    ref('product.product_uom_floz'),
+                ])]" />
+    </record>
+
+</odoo>

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,2 @@
 account-payment
+server-tools


### PR DESCRIPTION
This module sets the following UoM defaults for the `en_US` language:

* Hour (Working Time)
* Pound (Weight)
* Inch (Length)
* Oz (Volume)
* Unit (Unit)

This depends on:
- [x] https://github.com/OCA/server-tools/pull/930