### PR TITLE
[FIX] [10.0] l10n_us_check_writing_address: Add missing parser, Fix Travis

### DIFF
--- a/l10n_us_check_writing_address/__manifest__.py
+++ b/l10n_us_check_writing_address/__manifest__.py
@@ -4,21 +4,21 @@
 {
     'name': 'US Check Printing with Payee Address',
     'summary': 'Print US Checks',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'license': 'AGPL-3',
-    'author': 'Ursa Information Systems, Odoo Community Association (OCA)',
+    'author': 'Open Source Integrators, Odoo Community Association (OCA)',
     'category': 'Localization/Checks Printing',
-    'maintainer': 'Ursa Information Systems',
-    'website': 'http://www.ursainfosystems.com',
+    'maintainer': 'Open Source Integrators',
+    'website': 'https://www.opensourceintegrators.com',
     'depends': [
         'account_check_printing_report_base',
     ],
     'data': [
-        'report/account_check_writing_report.xml',
+        'data/account_payment_check_report_data.xml',
         'report/report_check_base_top.xml',
         'report/report_check_base_middle.xml',
         'report/report_check_base_bottom.xml',
-        'data/account_payment_check_report_data.xml',
+        'report/account_check_writing_report.xml',
     ],
     'installable': True,
 }

--- a/l10n_us_check_writing_address/report/__init__.py
+++ b/l10n_us_check_writing_address/report/__init__.py
@@ -2,5 +2,4 @@
 # Copyright 2017 Ursa Information Systems <http://www.ursainfosystems.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from . import models
-from . import report
+from . import check_print

--- a/l10n_us_check_writing_address/report/check_print.py
+++ b/l10n_us_check_writing_address/report/check_print.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Ursa Information Systems <http://www.ursainfosystems.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import time
+from odoo import api, models
+
+
+class ReportCheckPrintTop(models.AbstractModel):
+    _name = 'report.l10n_us_check_writing_address.report_check_base_top'
+    _inherit = 'report.account_check_printing_report_base.report_check_base'
+
+    @api.multi
+    def render_html(self, docids, data=None):
+        payments = self.env['account.payment'].browse(docids)
+        paid_lines = self.get_paid_lines(payments)
+        docargs = {
+            'doc_ids': docids,
+            'doc_model': 'account.payment',
+            'docs': payments,
+            'time': time,
+            'fill_stars': self.fill_stars,
+            'paid_lines': paid_lines
+        }
+        return self.env['report'].render(
+            'l10n_us_check_writing_address.report_check_base_top',
+            docargs)
+
+
+class ReportCheckPrintBottom(models.AbstractModel):
+    _name = 'report.l10n_us_check_writing_address.report_check_base_bottom'
+    _inherit = 'report.account_check_printing_report_base.report_check_base'
+
+    @api.multi
+    def render_html(self, docids, data=None):
+        payments = self.env['account.payment'].browse(docids)
+        paid_lines = self.get_paid_lines(payments)
+        docargs = {
+            'doc_ids': docids,
+            'doc_model': 'account.payment',
+            'docs': payments,
+            'time': time,
+            'fill_stars': self.fill_stars,
+            'paid_lines': paid_lines
+        }
+        return self.env['report'].render(
+            'l10n_us_check_writing_address.report_check_base_bottom',
+            docargs)
+
+
+class ReportCheckPrintMiddle(models.AbstractModel):
+    _name = 'report.l10n_us_check_writing_address.report_check_base_middle'
+    _inherit = 'report.account_check_printing_report_base.report_check_base'
+
+    @api.multi
+    def render_html(self, docids, data=None):
+        payments = self.env['account.payment'].browse(docids)
+        paid_lines = self.get_paid_lines(payments)
+        docargs = {
+            'doc_ids': docids,
+            'doc_model': 'account.payment',
+            'docs': payments,
+            'time': time,
+            'fill_stars': self.fill_stars,
+            'paid_lines': paid_lines
+        }
+        return self.env['report'].render(
+            'l10n_us_check_writing_address.report_check_base_middle',
+            docargs)

--- a/l10n_us_check_writing_address/report/report_check_base_bottom.xml
+++ b/l10n_us_check_writing_address/report/report_check_base_bottom.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-<data>
-    
-<template id="report_check_base_bottom">
+
+    <template id="report_check_base_bottom">
         <t t-call="report.html_container">
             <t t-foreach="docs" t-as="o">
                 <div class="page">
@@ -39,15 +38,15 @@
                                             </td>
                                             <td>
                                                 <span t-esc="line['amount_total']"
-                                                      t-esc-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                      t-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
                                             </td>
                                             <td>
                                                 <span t-esc="line['residual']"
-                                                      t-esc-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                      t-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
                                             </td>
                                             <td>
                                                 <span t-esc="line['paid_amount']"
-                                                      t-esc-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                      t-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
                                             </td>
                                         </tr>
                                     </t>
@@ -62,20 +61,19 @@
                         </t>
                     </div>
                     <div style="padding-top:20mm;">
-	                    <address t-field="o.partner_id"
-	                             t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true, "no_tag_br": true}'/>
-	
-	                    <span t-esc="o.payment_date"/>
-	                    <br/>
-	                    <span t-field="o.amount"
-	                          t-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
-	                    <br/>
-	                    <span t-esc="fill_stars(o.check_amount_in_words)"/>
-	                </div>
+                        <address t-field="o.partner_id"
+                                 t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true, "no_tag_br": true}'/>
+
+                        <span t-esc="o.payment_date"/>
+                        <br/>
+                        <span t-field="o.amount"
+                              t-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                        <br/>
+                        <span t-esc="fill_stars(o.check_amount_in_words)"/>
+                    </div>
                 </div>
             </t>
         </t>
     </template>
 
-</data>
 </odoo>

--- a/l10n_us_check_writing_address/report/report_check_base_middle.xml
+++ b/l10n_us_check_writing_address/report/report_check_base_middle.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-<data>
 
     <template id="report_check_base_middle">
         <t t-call="report.html_container">
@@ -38,15 +37,15 @@
                                             </td>
                                             <td>
                                                 <span t-esc="line['amount_total']"
-                                                      t-esc-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                                             </td>
                                             <td>
                                                 <span t-esc="line['residual']"
-                                                      t-esc-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                                             </td>
                                             <td>
                                                 <span t-esc="line['paid_amount']"
-                                                      t-esc-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                                             </td>
                                         </tr>
                                     </t>
@@ -56,19 +55,19 @@
                                  align="right">
                                 <b>Check Amount:</b>
                                 <span t-field="o.amount"
-                                      t-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                             </div>
                             <div t-if="i==0" style="padding-top:20mm;">
-		                        <address t-field="o.partner_id"
-		                                 t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true, "no_tag_br": true}'/>
-		
-		                        <span t-esc="o.payment_date"/>
-		                        <br/>
-		                        <span t-field="o.amount"
-		                              t-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
-		                        <br/>
-		                        <span t-esc="fill_stars(o.check_amount_in_words)"/>
-		                    </div>
+                                <address t-field="o.partner_id"
+                                         t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true, "no_tag_br": true}'/>
+        
+                                <span t-esc="o.payment_date"/>
+                                <br/>
+                                <span t-field="o.amount"
+                                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
+                                <br/>
+                                <span t-esc="fill_stars(o.check_amount_in_words)"/>
+                            </div>
                         </t>
                     </div>
                 </div>
@@ -76,5 +75,4 @@
         </t>
     </template>
 
-</data>
 </odoo>

--- a/l10n_us_check_writing_address/report/report_check_base_top.xml
+++ b/l10n_us_check_writing_address/report/report_check_base_top.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-<data>
 
     <template id="report_check_base_top">
         <t t-call="report.html_container">
@@ -13,7 +12,7 @@
                         <span t-esc="o.payment_date"/>
                         <br/>
                         <span t-field="o.amount"
-                              t-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                              t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                         <br/>
                         <span t-esc="fill_stars(o.check_amount_in_words)"/>
                     </div>
@@ -50,15 +49,15 @@
                                             </td>
                                             <td>
                                                 <span t-esc="line['amount_total']"
-                                                      t-esc-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                                             </td>
                                             <td>
                                                 <span t-esc="line['residual']"
-                                                      t-esc-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                                             </td>
                                             <td>
                                                 <span t-esc="line['paid_amount']"
-                                                      t-esc-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                                             </td>
                                         </tr>
                                     </t>
@@ -68,7 +67,7 @@
                                  align="right">
                                 <b>Check Amount:</b>
                                 <span t-field="o.amount"
-                                      t-options='{"widget": "monetary", "display_currency": "o.currency_id"}'/>
+                                      t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                             </div>
                         </t>
                     </div>
@@ -77,5 +76,4 @@
         </t>
     </template>
 
-</data>
 </odoo>


### PR DESCRIPTION
Fixes https://github.com/OCA/l10n-usa/issues/33
Follow up on https://github.com/OCA/l10n-usa/pull/8

Changes Made:
- Correct sequence for data files in manifest
- Add missing parsers
- Fix Travis:

  -  `[W7910(wrong-tabs-instead-of-spaces), ]`
  - `[W7943(xml-deprecated-qweb-directive), ]`
  - ` [W7939(deprecated-data-xml-node), ]`
  - Fix odoo.addons.base.ir.ir_qweb.ir_qweb: Use new syntax for 'b'<span t-tag="span"/>\n '' monetary widget t-options (python dict instead of deprecated JSON syntax).



To be added same on https://github.com/OCA/l10n-usa/pull/31