### PR TITLE
[12.0] l10n_us_gaap should use anglo saxon setting

### DIFF
--- a/l10n_us_gaap/data/account_chart_template_data.xml
+++ b/l10n_us_gaap/data/account_chart_template_data.xml
@@ -8,6 +8,7 @@
             <field name="bank_account_code_prefix">1111</field>
             <field name="cash_account_code_prefix">1112</field>
             <field name="transfer_account_code_prefix">1119</field>
+            <field name="use_anglo_saxon" eval="True" />
             <field name="currency_id" ref="base.USD"/>
         </record>
 </odoo>


### PR DESCRIPTION
Backport to 12.0 of https://github.com/OCA/l10n-usa/pull/56

Fast tracking.