### PR TITLE
[14.0][FIX] Generate ACH File Alphanumeric Error

### DIFF
--- a/account_banking_ach_base/models/account_payment_order.py
+++ b/account_banking_ach_base/models/account_payment_order.py
@@ -1,3 +1,4 @@
+import re
 from string import ascii_uppercase
 
 from ach.builder import AchFile
@@ -145,14 +146,17 @@ class AccountPaymentOrder(models.Model):
             self.validate_banking(line)
             amount = line.amount_currency
 
+            name = re.sub("[^A-Za-z0-9]+", "", line.partner_id.name)
+            note = re.sub("[^A-Za-z0-9]+", "", line.communication)
+
             entries.append(
                 {
                     "type": self.get_transaction_type(amount=amount),
                     "routing_number": line.partner_bank_id.bank_id.routing_number,
                     "account_number": line.partner_bank_id.acc_number,
                     "amount": str(amount),
-                    "name": line.partner_id.name,
-                    "addenda": [{"payment_related_info": line.communication}],
+                    "name": name,
+                    "addenda": [{"payment_related_info": note}],
                 }
             )
         outbound_payment = self.payment_type == "outbound"


### PR DESCRIPTION
Generate ACH File Alphanumeric Error

Steps to Reproduce:-

1) Create a Vendor Bill, Choose Vendor with proper Bank Account for ACH set
2) In the Payment Reference field enter +12345
3) Confirm Vendor Bill for Payment
4) Use Add to Pay Order function to add to Pay Order
5) Open the Payment Order, Confirm Payment Order, Generate File

See blocking error.

File "/home/workspace/odoo/src/l10n-usa/account_banking_ach_base/models/account_payment_order.py", line 176, in generate_ach_file
    ach_file.add_batch(
  File "/usr/local/lib/python3.8/site-packages/ach/builder.py", line 99, in add_batch
    self.batches.append(FileBatch(batch_header, entries))
  File "/usr/local/lib/python3.8/site-packages/ach/builder.py", line 240, in __init__
    self.entries.append(FileEntry(entry, addenda))
  File "/usr/local/lib/python3.8/site-packages/ach/builder.py", line 327, in __init__
    AddendaRecord(
  File "/usr/local/lib/python3.8/site-packages/ach/data_types.py", line 763, in __init__
    self.__setattr__(key, fields[key])
  File "/usr/local/lib/python3.8/site-packages/ach/data_types.py", line 774, in __setattr__
    value = self.validate_alpha_numeric_field(
  File "/usr/local/lib/python3.8/site-packages/ach/data_types.py", line 74, in validate_alpha_numeric_field
    raise AchError("field does not match alpha numeric criteria")
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/workspace/14.0/odoo/http.py", line 639, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/workspace/14.0/odoo/http.py", line 315, in _handle_exception
    raise exception.with_traceback(None) from new_cause
ach.data_types.AchError: field does not match alpha numeric criteria