### PR TITLE
[14.0][FIX] account_banking_ach_base: use the payment_ids field instead of bank_line_ids

### DIFF
--- a/account_banking_ach_base/models/account_payment_order.py
+++ b/account_banking_ach_base/models/account_payment_order.py
@@ -82,7 +82,7 @@ class AccountPaymentOrder(models.Model):
             raise UserError(
                 _(
                     "Missing ACH Direct Debit mandate on the "
-                    "bank payment line with partner '%s' "
+                    "payment line with partner '%s' "
                     "(reference '%s')."
                 )
                 % (line.partner_id.name, line.name)
@@ -140,7 +140,7 @@ class AccountPaymentOrder(models.Model):
             file_mod=file_mod,
         )
         entries = []
-        for line in self.bank_line_ids:
+        for line in self.payment_ids:
             if inbound_payment:
                 self.validate_mandates(line)
             self.validate_banking(line)

--- a/account_banking_ach_direct_debit/models/account_payment_order.py
+++ b/account_banking_ach_direct_debit/models/account_payment_order.py
@@ -30,18 +30,18 @@ class AccountPaymentOrder(models.Model):
         mandate = self.env["account.banking.mandate"]
         for order in self:
             to_expire_mandates = first_mandates = all_mandates = mandate
-            for bank_line in order.bank_line_ids:
-                if bank_line.mandate_id in all_mandates:
+            for payment in order.payment_ids:
+                if payment.mandate_id in all_mandates:
                     continue
-                all_mandates += bank_line.mandate_id
-                if bank_line.mandate_id.type == "oneoff":
-                    to_expire_mandates += bank_line.mandate_id
-                elif bank_line.mandate_id.type == "recurrent":
-                    seq_type = bank_line.mandate_id.recurrent_sequence_type
+                all_mandates += payment.mandate_id
+                if payment.mandate_id.type == "oneoff":
+                    to_expire_mandates += payment.mandate_id
+                elif payment.mandate_id.type == "recurrent":
+                    seq_type = payment.mandate_id.recurrent_sequence_type
                     if seq_type == "final":
-                        to_expire_mandates += bank_line.mandate_id
+                        to_expire_mandates += payment.mandate_id
                     elif seq_type == "first":
-                        first_mandates += bank_line.mandate_id
+                        first_mandates += payment.mandate_id
             all_mandates.write({"last_debit_date": order.date_generated})
             to_expire_mandates.write({"state": "expired"})
             first_mandates.write({"recurrent_sequence_type": "recurring"})


### PR DESCRIPTION
Fix the problems related to the refactor of account_payment_order


@ForgeFlow