### PR TITLE
[18.0][FIX] account_banking_ach_credit_transfer: fix tests

### DIFF
--- a/account_banking_ach_credit_transfer/tests/test_account_banking_ach_credit_transfer.py
+++ b/account_banking_ach_credit_transfer/tests/test_account_banking_ach_credit_transfer.py
@@ -64,7 +64,7 @@ class TestACHCreditTransfer(BaseCommon):
             )
         )
         line_create_form.date_type = "due"
-        line_create_form.due_date = fields.Date.today()
+        line_create_form.filter_date = fields.Date.today()
         line_create_form.payment_mode = "any"
         line_create_form.target_move = "all"
         line_created_due = line_create_form.save()

--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,3 +1,4 @@
 [checklog-odoo]
 ignore=
     WARNING.* 0 failed, 0 error\(s\).*
+    WARNING.* pkg_resources is deprecated as an API.*


### PR DESCRIPTION
The due_date field in the account.payment.line.create wizard was renamed to filter_date upstream in bank-payment/account_payment_order.