### PR TITLE
[16.0][FIX] account_banking_ach_base: use the payment_line_ids field instead of payment_ids

### DIFF
--- a/account_banking_ach_base/models/account_payment_order.py
+++ b/account_banking_ach_base/models/account_payment_order.py
@@ -130,13 +130,12 @@ class AccountPaymentOrder(models.Model):
             file_mod=file_mod,
         )
         entries = []
-        for line in self.payment_ids:
+        for line in self.payment_line_ids:
             if inbound_payment:
                 self.validate_mandates(line)
             self.validate_banking(line)
-            amount = line.amount
-            name = re.sub("[^A-Za-z0-9]+", "", line.partner_id.name)
-            note = re.sub("[^A-Za-z0-9]+", "", line.ref)
+            amount = line.amount_currency
+            name = re.sub(r"[^\w ,]", "", line.partner_id.name)
             entries.append(
                 {
                     "type": self.get_transaction_type(amount=amount),
@@ -144,7 +143,7 @@ class AccountPaymentOrder(models.Model):
                     "account_number": line.partner_bank_id.acc_number,
                     "amount": str(amount),
                     "name": name,
-                    "addenda": [{"payment_related_info": note}],
+                    "addenda": [{"payment_related_info": line.communication}],
                 }
             )
         outbound_payment = self.payment_type == "outbound"


### PR DESCRIPTION
- In version 14.0, we have a commit: [[14.0][FIX] use the payment_line_ids field instead of bank_line_ids](https://github.com/OCA/l10n-usa/commit/961400f5343eff05d72d302a92a0625b6b699ad0), but in version 16.0 this change has not been applied yet. We should update it to keep the flow consistent across versions.