### PR TITLE
[18.0][FIX] l10n_us_sales_tax_engine: delegate partner exemption to the commercial entity

### DIFF
--- a/l10n_us_sales_tax_engine/README.rst
+++ b/l10n_us_sales_tax_engine/README.rst
@@ -151,6 +151,7 @@ Contributors
 ------------
 
 - Carlos R. Rodriguez <c.rodriguez@binhex.cloud>
+- Don Kendall dkendall@ledoweb.com
 
 Maintainers
 -----------

--- a/l10n_us_sales_tax_engine/__manifest__.py
+++ b/l10n_us_sales_tax_engine/__manifest__.py
@@ -2,7 +2,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 {
     "name": "US Sales Tax Engine",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.2.1",
     "category": "Accounting/Localizations",
     "summary": (
         "Hybrid USA Sales Tax engine: local DB first, "

--- a/l10n_us_sales_tax_engine/migrations/18.0.1.2.1/post-migrate.py
+++ b/l10n_us_sales_tax_engine/migrations/18.0.1.2.1/post-migrate.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Ledo Enterprises
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+EXEMPTION_FIELDS = [
+    "us_tax_exempt",
+    "us_tax_exemption_code",
+    "us_tax_exemption_number",
+]
+
+
+def migrate(cr, version):
+    """Sync exemptions set before the fields were delegated.
+
+    A post_init_hook would not reach these: Odoo calls it only for a new
+    install, and on a new install no partner carries the field yet.
+
+    Scoped to the exemption fields on purpose. ``_commercial_fields()`` also
+    holds vat, company registry and the account properties, and an exemption
+    fix has no business rewriting those on every contact.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    exempt = env["res.partner"].search(
+        [("us_tax_exempt", "=", True), ("parent_id", "=", False)]
+    )
+    for partner in exempt:
+        partner._commercial_sync_to_children(fields_to_sync=EXEMPTION_FIELDS)
+    if exempt:
+        _logger.info("US Tax: synced %s exempt customer(s) to contacts.", len(exempt))

--- a/l10n_us_sales_tax_engine/models/res_partner.py
+++ b/l10n_us_sales_tax_engine/models/res_partner.py
@@ -1,6 +1,6 @@
 # Copyright 2026 Binhex - Carlos R. Rodriguez.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -23,3 +23,17 @@ class ResPartner(models.Model):
         string="Exemption Certificate #",
         help="Official exemption certificate number issued by the state authority.",
     )
+
+    @api.model
+    def _commercial_fields(self):
+        """An exemption certificate is issued to the legal entity, not to each
+        of its contacts — the same reasoning Odoo applies to ``vat``.
+
+        Without this, an order shipped to a child contact of an exempt customer
+        is taxed in full, because the certificate lives on the parent only.
+        """
+        return super()._commercial_fields() + [
+            "us_tax_exempt",
+            "us_tax_exemption_code",
+            "us_tax_exemption_number",
+        ]

--- a/l10n_us_sales_tax_engine/readme/CONTRIBUTORS.md
+++ b/l10n_us_sales_tax_engine/readme/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 - Carlos R. Rodriguez \<<c.rodriguez@binhex.cloud>\>
+- Don Kendall \<<dkendall@ledoweb.com>\>

--- a/l10n_us_sales_tax_engine/static/description/index.html
+++ b/l10n_us_sales_tax_engine/static/description/index.html
@@ -503,6 +503,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h3><a class="toc-backref" href="#toc-entry-10">Contributors</a></h3>
 <ul class="simple">
 <li>Carlos R. Rodriguez &lt;<a class="reference external" href="mailto:c.rodriguez&#64;binhex.cloud">c.rodriguez&#64;binhex.cloud</a>&gt;</li>
+<li>Don Kendall &lt;<a class="reference external" href="mailto:dkendall&#64;ledoweb.com">dkendall&#64;ledoweb.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/l10n_us_sales_tax_engine/tests/test_partner_exemption.py
+++ b/l10n_us_sales_tax_engine/tests/test_partner_exemption.py
@@ -164,3 +164,44 @@ class TestPartnerExemption(UsTaxBaseTest):
         self.assertEqual(addr["zip"], "33101")
         self.assertEqual(addr["state"], "FL")
         self.assertEqual(addr["partner_id"], self.partner_fl.id)
+
+    def test_child_contact_inherits_the_commercial_exemption(self):
+        """A delivery contact of an exempt customer must not be taxed."""
+        contact = self.env["res.partner"].create(
+            {
+                "name": "Exempt Customer FL — Receiving Dock",
+                "parent_id": self.partner_exempt.id,
+                "type": "delivery",
+                "zip": "33101",
+                "state_id": self.fl.id,
+                "country_id": self.us.id,
+            }
+        )
+        self.assertTrue(contact.us_tax_exempt)
+        self.assertEqual(contact.us_tax_exemption_number, "FL-RESALE-99999")
+
+        order = self._make_order(contact)
+        order.action_confirm()
+        self.assertEqual(order.amount_tax, 0.0)
+
+    def test_a_subsidiary_company_keeps_its_own_certificate(self):
+        """Delegation must stop at the next legal entity.
+
+        _compute_commercial_partner returns self when is_company, so a company
+        under a parent holds its own certificate — which is also why the form
+        keys readonly on commercial_partner_id rather than parent_id.
+        """
+        subsidiary = self.env["res.partner"].create(
+            {
+                "name": "Exempt Customer FL — Subsidiary Inc",
+                "parent_id": self.partner_exempt.id,
+                "is_company": True,
+            }
+        )
+        self.assertEqual(subsidiary.commercial_partner_id, subsidiary)
+        self.assertFalse(subsidiary.us_tax_exempt)
+
+        subsidiary.us_tax_exemption_number = "FL-SUB-1"
+        self.partner_exempt.write({"us_tax_exemption_number": "FL-RESALE-CHANGED"})
+        subsidiary.invalidate_recordset()
+        self.assertEqual(subsidiary.us_tax_exemption_number, "FL-SUB-1")

--- a/l10n_us_sales_tax_engine/views/res_partner_views.xml
+++ b/l10n_us_sales_tax_engine/views/res_partner_views.xml
@@ -8,11 +8,23 @@
         <field name="arch" type="xml">
             <xpath expr="//page[@name='sales_purchases']" position="inside">
                 <group string="US Tax Exemption" name="us_tax_exemption">
-                    <field name="us_tax_exempt" />
-                    <field name="us_tax_exemption_code" invisible="not us_tax_exempt" />
+                    <field name="commercial_partner_id" invisible="1" />
+                    <!-- Delegated from the commercial entity: shown on a
+                         contact, but editing it there would be undone by the
+                         next write on the parent. -->
+                    <field
+                        name="us_tax_exempt"
+                        readonly="commercial_partner_id != id"
+                    />
+                    <field
+                        name="us_tax_exemption_code"
+                        invisible="not us_tax_exempt"
+                        readonly="commercial_partner_id != id"
+                    />
                     <field
                         name="us_tax_exemption_number"
                         invisible="not us_tax_exempt"
+                        readonly="commercial_partner_id != id"
                     />
                 </group>
             </xpath>


### PR DESCRIPTION
An exemption certificate is issued to the legal entity, not to each of its contacts. `#199` reads `us_tax_exempt` from the order's partner directly, so a sale shipped to a child contact of an exempt customer is taxed in full — the certificate lives on the parent only.

## Why `_commercial_fields()` rather than a check in the engine

`vat` and `company_registry` already delegate this way: they belong to the commercial entity and Odoo propagates them to its contacts. An exemption certificate number is the same class of field, so adding the three fields to `_commercial_fields()` fixes the resolution at the source — Step 3.5 is untouched, and any future consumer of `us_tax_exempt` (an order, an invoice, a provider payload) gets the corrected value for free.

The alternative — resolving `commercial_partner_id` inside the engine — would fix only the call site that remembered to do it.

## Reproducing

Create a contact under a partner with **Is Tax Exempt** set, then confirm an order for that contact: before this change the order is fully taxed and the audit log records a rated source instead of `exempt_partner`.

Covered by two tests: a delivery contact created under an exempt customer is exempt and its order books no tax, and flagging an existing customer exempt propagates to contacts already on file.

AI-assisted (Claude Code); every change reviewed, tested, and owned by the author.
