### PR TITLE
[FIX] l10n_us_form_1099: add missing 1099-NEC type

### DIFF
--- a/l10n_us_form_1099/data/type_1099_data.xml
+++ b/l10n_us_form_1099/data/type_1099_data.xml
@@ -32,6 +32,9 @@
     <record id="1099_type_misc" model="type.1099">
         <field name="name">1099-MISC</field>
     </record>
+    <record id="1099_type_nec" model="type.1099">
+        <field name="name">1099-NEC</field>
+    </record>
     <record id="1099_type_oid" model="type.1099">
         <field name="name">1099-OID</field>
     </record>


### PR DESCRIPTION
## Problem

`type.1099` ships 19 records, but **Form 1099-NEC is missing**.

The IRS reintroduced Form 1099-NEC for tax year 2020, moving nonemployee
compensation out of box 7 of Form 1099-MISC onto its own form. For most
businesses this is the single most frequently issued 1099 — it is the form used
to report payments to independent contractors.

As a result, a user classifying a contractor cannot select the correct form.

## Change

Adds one data record, `1099_type_nec`, between the existing MISC and OID
entries so the file keeps its current ordering.

Data-only, no schema change, no dependency change. `noupdate` is not set on this
file, so existing databases pick the record up on module update.

## Note, out of scope for this PR

`data/box_1099_misc_data.xml` still describes the pre-2020 1099-MISC layout —
box 7 is labelled *Nonemployee Compensation*, which since 2020 is box 1 of the
1099-NEC, while box 7 of the MISC became *Payer made direct sales*. Renumbering
those records would alter data users may already have assigned, so it is left
for a separate discussion.
